### PR TITLE
Improvements

### DIFF
--- a/files/.bashrc
+++ b/files/.bashrc
@@ -30,11 +30,75 @@ shopt -s checkwinsize
 # make less more friendly for non-text input files, see lesspipe(1)
 #[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
 
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+        # We have color support; assume it's compliant with Ecma-48
+        # (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+        # a case would tend to support setf rather than setaf.)
+        color_prompt=yes
+    else
+        color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[00;32m\]\u@\h\[\033[00m\]:\[\033[00;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+
+    alias sudo='sudo '
+
+    alias ls='ls -F --color=auto'
+    alias ll='ls -Fhl --color=auto'
+    alias la='ls -AFhl --color=auto'
+
+    alias dir='dir --color=auto'
+    alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+else
+    alias ls='ls -F'
+    alias ll='ls -Fhl'
+    alias la='ls -AFhl'
+fi
+
 # Alias definitions.
 # You may want to put all your additions into a separate file like
 # ~/.bash_aliases, instead of adding them here directly.
 # See /usr/share/doc/bash-doc/examples in the bash-doc package.
-
 if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi

--- a/files/bash.bashrc
+++ b/files/bash.bashrc
@@ -15,43 +15,16 @@ if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
     debian_chroot=$(cat /etc/debian_chroot)
 fi
 
-# set a fancy prompt (non-color, unless we know we "want" color)
-case "$TERM" in
-    *color)
-        color_prompt=yes
-        ;;
-esac
+# set a fancy prompt (non-color, overwrite the one in /etc/profile)
+PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 
-if [ "$color_prompt" = yes ]; then
-    if [[ ${EUID} == 0 ]] ; then
-        PS1='${debian_chroot:+($debian_chroot)}\[\033[31m\]\h\[\033[34m\] \W \$\[\033[00m\] '
-    else
-        PS1='${debian_chroot:+($debian_chroot)}\[\033[32m\]\u@\h\[\033[34m\] \w \$\[\033[00m\] '
-    fi
-else
-    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
-fi
-
-unset color_prompt
-
-# Commented out, don't overwrite xterm -T "title" -n "icontitle" by default.
-# If this is an xterm set the title to user@host:dir
-case ${TERM} in
-    xterm*|rxvt*|Eterm*|aterm|kterm|gnome*|interix)
-        PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\007"'
-        ;;
-    screen*)
-        PROMPT_COMMAND='echo -ne "\033_${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\033\\"'
-        ;;
-esac
-
-# enable programmable completion features
+# enable bash completion in interactive shells
 if ! shopt -oq posix; then
-  if [ -f /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
-  elif [ -f /etc/bash_completion ]; then
-    . /etc/bash_completion
-  fi
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+        . /usr/share/bash-completion/bash_completion
+    elif [ -f /etc/bash_completion ]; then
+        . /etc/bash_completion
+    fi
 fi
 
 # if the command-not-found package is installed, use it
@@ -69,23 +42,4 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
             return 127
         fi
     }
-fi
-
-# enable color support of ls and also add handy aliases
-if [ -x /usr/bin/dircolors ]; then
-    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
-
-    alias sudo='sudo '
-
-    alias ls='ls -F --color=auto'
-    alias ll='ls -Fhl --color=auto'
-    alias la='ls -AFhl --color=auto'
-
-    alias grep='grep --colour=auto'
-    alias egrep='egrep --colour=auto'
-    alias fgrep='fgrep --colour=auto'
-else
-    alias ls='ls -F'
-    alias ll='ls -Fhl'
-    alias la='ls -AFhl'
 fi

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,12 +3,14 @@ galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
   description: Install a nice bash profile
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.4
   platforms:
   - name: Debian
     versions:
       - wheezy
+      - jessie
+      - stretch
   galaxy_tags:
     - system
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,10 @@
     - /root
     - /etc/skel
 
-- name: write current user homedir .bashrc
-  copy: "src=.bashrc dest={{ ansible_env['HOME'] }}/.bashrc owner={{ ansible_user_id }} group={{ ansible_user_id }} mode=0644"
+- name: determine ssh user homedir
+  shell: "getent passwd {{ ansible_ssh_user }} | cut -d: -f6"
+  register: bashrc_homedir
+  changed_when: False
+
+- name: write ssh user homedir .bashrc
+  copy: "src=.bashrc dest={{ bashrc_homedir.stdout }}/.bashrc owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} mode=0644"


### PR DESCRIPTION
Configuration files are shuffled a bit, nothing really changes, but it's more in line with how they look when you freshly install Debian.

Fixed writing `.bashrc` to `/home/vagrant` (the logged in user). Previous task accidentally writes it to `/root` when "sudo" (or "become") is enabled.

Tested on Wheezy, Jessie and Stretch.