### PR TITLE
Which users get .bashrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,17 @@ also as skeleton for future users created on this system.
 Requirements
 ------------
 
-Debian Wheezy with the package python-pycurl and python-software-properties installed.
+Debian Wheezy/Jessie/Stretch with the package python-pycurl and python-software-properties installed.
 Also, you need bash for this to be of any use.
+
+Role Variables
+--------------
+
+You can specify which users will get a `.bashrc` written to their homedir.
+By default this roles uses the Ansible SSH user.
+
+    bashrc_users:
+      - "{{ ansible_ssh_user }}"
 
 Example Playbook
 -------------------------
@@ -23,7 +32,7 @@ Example Playbook
 License
 -------
 
-LGPL
+LGPL-3.0
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+bashrc_users:
+  - "{{ ansible_ssh_user }}"

--- a/files/.bashrc
+++ b/files/.bashrc
@@ -57,9 +57,13 @@ if [ -n "$force_color_prompt" ]; then
 fi
 
 if [ "$color_prompt" = yes ]; then
-    PS1='${debian_chroot:+($debian_chroot)}\[\033[00;32m\]\u@\h\[\033[00m\]:\[\033[00;34m\]\w\[\033[00m\]\$ '
+    if [[ $EUID -eq 0 ]]; then
+        PS1='${debian_chroot:+($debian_chroot)}\[\033[00;31m\]\u\[\033[0m\]@\[\033[00;32m\]\h\[\033[0m\]:\[\033[00;34m\]\w\[\033[0m\] \$ '
+    else
+        PS1='${debian_chroot:+($debian_chroot)}\[\033[00;32m\]\u\[\033[0m\]@\[\033[00;32m\]\h\[\033[0m\]:\[\033[00;34m\]\w\[\033[0m\] \$ '
+    fi
 else
-    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w \$ '
 fi
 
 unset color_prompt force_color_prompt

--- a/files/bash.bashrc
+++ b/files/bash.bashrc
@@ -16,7 +16,7 @@ if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
 fi
 
 # set a fancy prompt (non-color, overwrite the one in /etc/profile)
-PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w \$ '
 
 # enable bash completion in interactive shells
 if ! shopt -oq posix; then

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,11 @@
     - /etc/skel
 
 - name: determine ssh user homedir
-  shell: "getent passwd {{ ansible_ssh_user }} | cut -d: -f6"
-  register: bashrc_homedir
+  shell: "getent passwd {{ item }} | cut -d: -f6"
+  register: bashrc_homedirs
+  with_items: "{{ bashrc_users }}"
   changed_when: False
 
 - name: write ssh user homedir .bashrc
-  copy: "src=.bashrc dest={{ bashrc_homedir.stdout }}/.bashrc owner={{ ansible_ssh_user }} group={{ ansible_ssh_user }} mode=0644"
+  copy: "src=.bashrc dest={{ item.stdout }}/.bashrc owner={{ item.item }} group={{ item.item }} mode=0644"
+  with_items: "{{ bashrc_homedirs.results }}"


### PR DESCRIPTION
Add variable to specify which users should get a `.bashrc` in their homedir.
Improve the prompt (nicer coloring, red when root).

After merge I recommend tagging `v1.1.0`.