### PR TITLE
Replace ansible_ssh_user with a hardcoded default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
 bashrc_users:
-  - "{{ ansible_ssh_user }}"
+  - "provision"


### PR DESCRIPTION
ansible_ssh_user does not exist (anymore)